### PR TITLE
ci: install Tauri CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked
       - name: Tauri build
         run: cargo tauri build --target x86_64-pc-windows-msvc
       - name: Upload artifacts


### PR DESCRIPTION
## Summary
- install Tauri CLI before building in CI workflow

## Testing
- `npm test` (fails: missing script "test")
- `cargo test` (fails: The system library `glib-2.0` required by crate `glib-sys` was not found)


------
https://chatgpt.com/codex/tasks/task_e_68902336d2e4832d8d37e7c0ab1304c4